### PR TITLE
Internal API changes

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func ExampleNewEpsilonGreedy() {
-	hp := NewEpsilonGreedy([]string{"a", "b"}, 0, &LinearEpsilonValueCalculator{})
-	hostResponse := Get(hp)
+	hp := NewWithSelector([]string{"a", "b"}, NewEpsilonGreedy(0, &LinearEpsilonValueCalculator{}))
+	hostResponse := hp.Get()
 	hostname := hostResponse.Host()
 	err := errors.New("I am your http error from " + hostname) // (make a request with hostname)
 	hostResponse.Mark(err)

--- a/selector.go
+++ b/selector.go
@@ -1,0 +1,118 @@
+package hostpool
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+type Selector interface {
+	Init([]string)
+	SelectNextHost() string
+	MakeHostResponse(string) HostPoolResponse
+	MarkHost(string, error)
+	ResetAll()
+}
+
+type standardSelector struct {
+	sync.RWMutex
+	hosts             map[string]*hostEntry
+	hostList          []*hostEntry
+	initialRetryDelay time.Duration
+	maxRetryInterval  time.Duration
+	nextHostIndex     int
+}
+
+func (s *standardSelector) Init(hosts []string) {
+	s.hosts = make(map[string]*hostEntry, len(hosts))
+	s.hostList = make([]*hostEntry, len(hosts))
+	s.initialRetryDelay = time.Duration(30) * time.Second
+	s.maxRetryInterval = time.Duration(900) * time.Second
+
+	for i, h := range hosts {
+		e := &hostEntry{
+			host:       h,
+			retryDelay: s.initialRetryDelay,
+		}
+		s.hosts[h] = e
+		s.hostList[i] = e
+	}
+}
+
+func (s *standardSelector) SelectNextHost() string {
+	s.Lock()
+	host := s.getRoundRobin()
+	s.Unlock()
+	return host
+}
+
+func (s *standardSelector) getRoundRobin() string {
+	now := time.Now()
+	hostCount := len(s.hostList)
+	for i := range s.hostList {
+		// iterate via sequenece from where we last iterated
+		currentIndex := (i + s.nextHostIndex) % hostCount
+
+		h := s.hostList[currentIndex]
+		if h.canTryHost(now) {
+			s.nextHostIndex = currentIndex + 1
+			return h.host
+		}
+	}
+
+	// all hosts are down. re-add them
+	s.doResetAll()
+	s.nextHostIndex = 0
+	return s.hostList[0].host
+}
+
+func (s *standardSelector) MakeHostResponse(host string) HostPoolResponse {
+	s.Lock()
+	defer s.Unlock()
+	h, ok := s.hosts[host]
+	if !ok {
+		log.Fatalf("host %s not in HostPool", host)
+	}
+	now := time.Now()
+	if h.dead && h.nextRetry.Before(now) {
+		h.willRetryHost(s.maxRetryInterval)
+	}
+	return &standardHostPoolResponse{host: host, ss: s}
+}
+
+func (s *standardSelector) MarkHost(host string, err error) {
+	s.Lock()
+	defer s.Unlock()
+
+	h, ok := s.hosts[host]
+	if !ok {
+		log.Fatalf("host %s not in HostPool", host)
+	}
+	if err == nil {
+		// success - mark host alive
+		h.dead = false
+	} else {
+		// failure - mark host dead
+		if !h.dead {
+			h.dead = true
+			h.retryCount = 0
+			h.retryDelay = s.initialRetryDelay
+			h.nextRetry = time.Now().Add(h.retryDelay)
+		}
+	}
+}
+
+func (s *standardSelector) ResetAll() {
+	s.Lock()
+	defer s.Unlock()
+	s.doResetAll()
+}
+
+// this actually performs the logic to reset,
+// and should only be called when the lock has
+// already been acquired
+func (s *standardSelector) doResetAll() {
+	for _, h := range s.hosts {
+		h.dead = false
+	}
+}


### PR DESCRIPTION
Just wanted to put some work I've done on the internal api changes up for folks to look at. The main goal of all this stuff is to increase the separation between the epsilon-greedy stuff and the standard hostpool so they can be composed as desired. I'll try to summarize the main changes:
- The `epsilonGreedyHostPoolResponse` keeps a pointer to a `epsilonGreedyHostPool` struct, not the interface. Internally it embeds a `HostPoolResponse` - the interface, not the basic struct impl.
- The `epsilonGreedyHostPool` embeds the `HostPool` interface, not the basic struct impl
- The various `HostPoolResponse` impls no longer have a `sync.Once`. I don't think there should be any expectation that they be threadsafe
- The `HostPool` interface now has a private `selectHost` method to produce a `HostPoolResponse` from a host string. This also takes care of any state changes involved in selecting that host, such as dealing with retry time and starting a time for epsilonGreedy operation
- `getRoundRobin` and `getEpsilonGreedy` just select a hostname. The `selectHost` method takes care of other state changes involved in delivering the `HostResponse` to the user.

I have some more changes in mind that I would eventually like to make in the service of the separation I mentioned, but I think that this is a good place to start. The tests pass, though I did have to change them slightly: I have to make a couple of type assertions, and I had to remove one line that tested the `sync.Once` functionality of the `HostPoolResponse`s.

cc @jehiah @mreiferson  
