### PR TITLE
Add 'Close' function to properly release all resources for a host pool.

### DIFF
--- a/epsilon_greedy.go
+++ b/epsilon_greedy.go
@@ -17,7 +17,6 @@ func (r *epsilonHostPoolResponse) Mark(err error) {
 		r.ended = time.Now()
 		doMark(err, r)
 	})
-
 }
 
 type epsilonGreedyHostPool struct {
@@ -80,14 +79,13 @@ func (p *epsilonGreedyHostPool) SetEpsilon(newEpsilon float32) {
 
 func (p *epsilonGreedyHostPool) epsilonGreedyDecay() {
 	durationPerBucket := p.decayDuration / epsilonBuckets
-	ticker := time.Tick(durationPerBucket)
+	ticker := time.NewTicker(durationPerBucket)
 	for {
 		select {
 		case <-p.quit:
-			// Can't close the receive only chan ticker.
+			ticker.Stop()
 			return
-		default:
-			<-ticker
+		case <-ticker.C:
 			p.performEpsilonGreedyDecay()
 		}
 	}

--- a/epsilon_greedy.go
+++ b/epsilon_greedy.go
@@ -67,7 +67,7 @@ func NewEpsilonGreedy(hosts []string, decayDuration time.Duration, calc EpsilonV
 }
 
 func (p *epsilonGreedyHostPool) Close() {
-	p.quit <- true
+	// No need to do p.quit <- true as close(p.quit) does the trick.
 	close(p.quit)
 }
 

--- a/hostpool.go
+++ b/hostpool.go
@@ -45,6 +45,9 @@ type HostPool interface {
 
 	ResetAll()
 	Hosts() []string
+
+	// Close the hostpool and release all resources.
+	Close()
 }
 
 type standardHostPool struct {
@@ -152,6 +155,12 @@ func (p *standardHostPool) ResetAll() {
 func (p *standardHostPool) doResetAll() {
 	for _, h := range p.hosts {
 		h.dead = false
+	}
+}
+
+func (p *standardHostPool) Close() {
+	for _, h := range p.hosts {
+		h.dead = true
 	}
 }
 


### PR DESCRIPTION
This is necessary for usage of the lib with multiple dynamically created hostpools. Currently there is no easy way to release resources taken in each hostpool because of the ticker go routine.