### PR TITLE
Fix import cycle and build error

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -1,4 +1,4 @@
-package hostpool
+package hostpool_test
 
 import (
 	"github.com/bitly/go-hostpool"
@@ -7,7 +7,6 @@ import (
 func ExampleNewEpsilonGreedy() {
 	hp := hostpool.NewEpsilonGreedy([]string{"a", "b"}, 0, &hostpool.LinearEpsilonValueCalculator{})
 	hostResponse := hp.Get()
-	hostname := hostResponse.Host()
-	err := nil // (make a request with hostname)
-	hostResponse.Mark(err)
+	_ = hostResponse.Host()
+	hostResponse.Mark(nil)
 }


### PR DESCRIPTION
Importing the current package from it's external source creates an import cycle; changing the package name for this test breaks the cycle. Also, "err := nil" is ambiguous and causes a compile-time failure.