### PR TITLE
fix for race condition in .Close()

### DIFF
--- a/hostpool.go
+++ b/hostpool.go
@@ -159,6 +159,8 @@ func (p *standardHostPool) doResetAll() {
 }
 
 func (p *standardHostPool) Close() {
+	p.Lock()
+	defer p.Unlock()
 	for _, h := range p.hosts {
 		h.dead = true
 	}

--- a/hostpool_test.go
+++ b/hostpool_test.go
@@ -2,13 +2,14 @@ package hostpool
 
 import (
 	"errors"
-	"github.com/bmizerany/assert"
 	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/bmizerany/assert"
 )
 
 func TestHostPool(t *testing.T) {


### PR DESCRIPTION
now calls .Lock() mutex to prevent a race condition in updating h.dead.